### PR TITLE
chore: Improve zustand mock

### DIFF
--- a/src/__mocks__/zustand.js
+++ b/src/__mocks__/zustand.js
@@ -5,14 +5,23 @@ const { act } = require('react-dom/test-utils');
 const storeResetFns = new Set();
 
 const create = (createState) => {
-  const store = actualCreate(createState);
-
   /**
-   * if createState is empty, store won't have a getState function
-   * then we need to skip associating this value
+   * If createState is empty, store won't have a getState function
+   * and it will be the real createImpl function.
+   *
+   * In this situation, we need to make sure to return the function
+   * itself to be able to intercept the original createState function
+   * and be able to reset the store after each test.
+   *
    * This happens whenever we use the following syntax
    * create()(...) to help TS auto completion
    */
+  if (createState === undefined) {
+    return create;
+  }
+
+  const store = actualCreate(createState);
+
   if (typeof store.getState === 'function') {
     /** when creating a store, we get its initial state, create a reset function and add it in the set */
     const initialState = store.getState();

--- a/src/store/nestedStepsStore.tsx
+++ b/src/store/nestedStepsStore.tsx
@@ -11,7 +11,7 @@ export interface INestedStepStore {
 
 const initialState: INestedStep[] = [];
 
-export const useNestedStepsStore = create<INestedStepStore>()((set, get) => ({
+export const useNestedStepsStore = create<INestedStepStore>((set, get) => ({
   ...initialState,
   addStep: (newStep) => {
     set((state) => {


### PR DESCRIPTION
If `createState` is empty, the store won't have a `getState` function and it will be the real `createImpl` function instead.

In this situation, we need to make sure to return the function itself to be able to intercept the original createState function and be able to reset the store after each test.